### PR TITLE
Fix Apple Music user playlist URLs

### DIFF
--- a/src/main/java/com/github/topislavalinkplugins/topissourcemanagers/applemusic/AppleMusicSourceManager.java
+++ b/src/main/java/com/github/topislavalinkplugins/topissourcemanagers/applemusic/AppleMusicSourceManager.java
@@ -35,7 +35,7 @@ public class AppleMusicSourceManager extends ISRCAudioSourceManager implements H
 
 	private static final Logger log = LoggerFactory.getLogger(AppleMusicSourceManager.class);
 
-	public static final Pattern APPLE_MUSIC_URL_PATTERN = Pattern.compile("(https?://)?(www\\.)?music\\.apple\\.com/(?<countrycode>[a-zA-Z]{2}/)?(?<type>album|playlist|artist|song)(/[a-zA-Z\\d\\-]+)?/(?<identifier>[a-zA-Z\\d.]+)(\\?i=(?<identifier2>\\d+))?");
+	public static final Pattern APPLE_MUSIC_URL_PATTERN = Pattern.compile("(https?://)?(www\\.)?music\\.apple\\.com/(?<countrycode>[a-zA-Z]{2}/)?(?<type>album|playlist|artist|song)(/[a-zA-Z\\d\\-]+)?/(?<identifier>[a-zA-Z\\d\\-.]+)(\\?i=(?<identifier2>\\d+))?");
 	public static final String SEARCH_PREFIX = "amsearch:";
 	public static final int MAX_PAGE_ITEMS = 300;
 


### PR DESCRIPTION
This should fix user-created playlist URLs with ids at the end like `pl.u-dj3dijmfikl7HY5z` (probably not a real ID, just an example based off of a real one I saw).